### PR TITLE
CX-1734: pass redirect query params through with overridden status and message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.17
+
+- Include query params from redirect URL in callback response, with `status` and `message` overridden to `SUCCESS` and `Link closed after redirect`.
+
 ## 3.0.16
 
 - Support optional `showConsentExplanation` in `connect` method.

--- a/lib/lean.dart
+++ b/lib/lean.dart
@@ -55,7 +55,7 @@ class LeanSDK {
       "platform": "mobile",
       "sdk": "flutter",
       "os": Platform.operatingSystem.toString(),
-      "sdk_version": '3.0.16', // @todo: get this dynamically from pubspec.yaml
+      "sdk_version": '3.0.17', // @todo: get this dynamically from pubspec.yaml
       "is_version_pinned": _version != "latest"
     };
 

--- a/lib/lean_web_client.dart
+++ b/lib/lean_web_client.dart
@@ -51,9 +51,19 @@ class LeanWebClient {
       if (uri.host == 'redirect') {
         LeanLogger.info(msg: 'Redirect received: ${request.url}');
         _redirectFired = true; // guard against late duplicates
+        final redirectParams = _getResponseFromParams(uri);
         callback?.call(LeanResponse(
           status: 'SUCCESS',
           message: 'Link closed after redirect',
+          bankId: redirectParams.bankId,
+          exitPoint: redirectParams.exitPoint,
+          lastApiResponse: redirectParams.lastApiResponse,
+          secondaryStatus: redirectParams.secondaryStatus,
+          bankIsSupported: redirectParams.bankIsSupported,
+          exitIntentPoint: redirectParams.exitIntentPoint,
+          exitSurveyReason: redirectParams.exitSurveyReason,
+          leanCorrelationId: redirectParams.leanCorrelationId,
+          userExitIntent: redirectParams.userExitIntent,
         ));
       } else {
         LeanLogger.info(msg: 'Response received: ${request.url}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lean_sdk_flutter
 description: Lean SDK Flutter.
-version: 3.0.16
+version: 3.0.17
 homepage: https://github.com/leantechnologies/link-sdk-flutter
 
 environment:


### PR DESCRIPTION
## Summary
- On the `leanlink://redirect` path, the callback previously only sent a hardcoded `status: SUCCESS` and `message` with no other fields
- Now parses all query params from the redirect URL and includes them in the response, while still overriding `status` and `message` — matching the existing JS SDK behaviour