### PR TITLE
PBB-669 support accountId & allowPaymentSourceChange in pay checkout and authorizeConsent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.18
+
+- Add `allowPaymentSourceChange` as an optional parameter to `pay`, `authorizeConsent`, and `checkout` methods.
+- Support accountId and bankIdentifier in `checkout` and `authorizeConsent` method.
+
 ## 3.0.17
 
 - Include query params from redirect URL in callback response, with `status` and `message` overridden to `SUCCESS` and `Link closed after redirect`.

--- a/lib/lean.dart
+++ b/lib/lean.dart
@@ -55,7 +55,7 @@ class LeanSDK {
       "platform": "mobile",
       "sdk": "flutter",
       "os": Platform.operatingSystem.toString(),
-      "sdk_version": '3.0.17', // @todo: get this dynamically from pubspec.yaml
+      "sdk_version": '3.0.18', // @todo: get this dynamically from pubspec.yaml
       "is_version_pinned": _version != "latest"
     };
 
@@ -372,6 +372,7 @@ class LeanSDK {
     String? destinationAlias,
     String? destinationAvatar,
     RiskDetails? riskDetails,
+    bool? allowPaymentSourceChange,
   }) {
     String customizationParams = _convertCustomizationToURLString();
 
@@ -384,6 +385,7 @@ class LeanSDK {
       Params.account_id.name: accountId,
       Params.bank_identifier.name: bankIdentifier,
       Params.show_balances.name: showBalances,
+      Params.allow_payment_source_change.name: allowPaymentSourceChange,
       Params.access_token.name: accessToken,
       Params.fail_redirect_url.name: failRedirectUrl,
       Params.success_redirect_url.name: successRedirectUrl,
@@ -435,9 +437,12 @@ class LeanSDK {
     required String failRedirectUrl,
     required String successRedirectUrl,
     String? accessToken,
+    String? bankIdentifier,
+    String? accountId,
     String? destinationAlias,
     String? destinationAvatar,
     RiskDetails? riskDetails,
+    bool? allowPaymentSourceChange,
   }) {
     String customizationParams = _convertCustomizationToURLString();
 
@@ -446,6 +451,9 @@ class LeanSDK {
 
     final optionalParams = {
       Params.access_token.name: accessToken,
+      Params.bank_identifier.name: bankIdentifier,
+      Params.account_id.name: accountId,
+      Params.allow_payment_source_change.name: allowPaymentSourceChange,
       Params.destination_alias.name: destinationAlias,
       Params.destination_avatar.name: destinationAvatar,
     };
@@ -467,7 +475,9 @@ class LeanSDK {
     String? accessToken,
     String? customerName,
     String? bankIdentifier,
+    String? accountId,
     RiskDetails? riskDetails,
+    bool? allowPaymentSourceChange,
   }) {
     String customizationParams = _convertCustomizationToURLString();
 
@@ -478,6 +488,8 @@ class LeanSDK {
       Params.access_token.name: accessToken,
       Params.customer_name.name: customerName,
       Params.bank_identifier.name: bankIdentifier,
+      Params.account_id.name: accountId,
+      Params.allow_payment_source_change.name: allowPaymentSourceChange,
     };
 
     initializationURL = _appendOptionalConfigToURLParams(

--- a/lib/lean_sdk_flutter.dart
+++ b/lib/lean_sdk_flutter.dart
@@ -36,6 +36,7 @@ class Lean extends StatefulWidget {
   final String? reconnectId;
   final String? consentId;
   final bool? showBalances;
+  final bool? allowPaymentSourceChange;
   final LeanCallback? callback;
   final String? bankIdentifier;
   final String? paymentIntentId;
@@ -87,6 +88,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.connect,
+        allowPaymentSourceChange = null,
         accountId = null,
         reconnectId = null,
         customerName = null,
@@ -118,6 +120,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.reconnect,
+        allowPaymentSourceChange = null,
         accessTo = null,
         accountId = null,
         customerId = null,
@@ -161,6 +164,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.createBeneficiary,
+        allowPaymentSourceChange = null,
         accessTo = null,
         accountId = null,
         accessFrom = null,
@@ -202,6 +206,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.createPaymentSource,
+        allowPaymentSourceChange = null,
         accessTo = null,
         accountId = null,
         accessFrom = null,
@@ -241,6 +246,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.updatePaymentSource,
+        allowPaymentSourceChange = null,
         accessTo = null,
         accountId = null,
         accessFrom = null,
@@ -277,6 +283,7 @@ class Lean extends StatefulWidget {
     this.accountId,
     this.bankIdentifier,
     this.showBalances,
+    this.allowPaymentSourceChange,
     this.failRedirectUrl,
     this.successRedirectUrl,
     this.riskDetails,
@@ -318,6 +325,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.verifyAddress,
+        allowPaymentSourceChange = null,
         accessTo = null,
         accessFrom = null,
         bankIdentifier = null,
@@ -355,7 +363,10 @@ class Lean extends StatefulWidget {
     this.env = 'production',
     this.country = LeanCountry.ae,
     this.language = LeanLanguage.en,
+    this.bankIdentifier,
+    this.accountId,
     this.riskDetails,
+    this.allowPaymentSourceChange,
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.authorizeConsent,
@@ -364,10 +375,8 @@ class Lean extends StatefulWidget {
         reconnectId = null,
         permissions = null,
         customerName = null,
-        bankIdentifier = null,
         paymentSourceId = null,
         paymentIntentId = null,
-        accountId = null,
         showBalances = null,
         customerMetadata = null,
         showConsentExplanation = null,
@@ -395,14 +404,15 @@ class Lean extends StatefulWidget {
     this.language = LeanLanguage.en,
     this.customerName,
     this.bankIdentifier,
+    this.accountId,
     this.riskDetails,
+    this.allowPaymentSourceChange,
   })  : _method = LeanMethods.checkout,
         customerId = null,
         permissions = null,
         accessTo = null,
         accessFrom = null,
         paymentDestinationId = null,
-        accountId = null,
         reconnectId = null,
         consentId = null,
         showBalances = null,
@@ -431,6 +441,7 @@ class Lean extends StatefulWidget {
     this.country = LeanCountry.ae,
     this.language = LeanLanguage.en,
   })  : _method = LeanMethods.manageConsents,
+        allowPaymentSourceChange = null,
         permissions = null,
         accessTo = null,
         accessFrom = null,
@@ -474,6 +485,7 @@ class Lean extends StatefulWidget {
     this.granularStatusCode,
     this.statusAdditionalInfo,
   })  : _method = LeanMethods.captureRedirect,
+        allowPaymentSourceChange = null,
         permissions = null,
         accessTo = null,
         accessFrom = null,
@@ -583,6 +595,7 @@ class _LeanState extends State<Lean> {
         accountId: widget.accountId,
         bankIdentifier: widget.bankIdentifier,
         showBalances: widget.showBalances,
+        allowPaymentSourceChange: widget.allowPaymentSourceChange,
         failRedirectUrl: widget.failRedirectUrl,
         successRedirectUrl: widget.successRedirectUrl,
         accessToken: widget.accessToken,
@@ -608,7 +621,10 @@ class _LeanState extends State<Lean> {
         failRedirectUrl: widget.failRedirectUrl!,
         successRedirectUrl: widget.successRedirectUrl!,
         accessToken: widget.accessToken,
+        bankIdentifier: widget.bankIdentifier,
+        accountId: widget.accountId,
         riskDetails: widget.riskDetails,
+        allowPaymentSourceChange: widget.allowPaymentSourceChange,
         destinationAlias: widget.destinationAlias,
         destinationAvatar: widget.destinationAvatar);
   }
@@ -621,7 +637,9 @@ class _LeanState extends State<Lean> {
         accessToken: widget.accessToken,
         customerName: widget.customerName,
         bankIdentifier: widget.bankIdentifier,
-        riskDetails: widget.riskDetails);
+        accountId: widget.accountId,
+        riskDetails: widget.riskDetails,
+        allowPaymentSourceChange: widget.allowPaymentSourceChange);
   }
 
   String get _manageConsents {

--- a/lib/lean_types.dart
+++ b/lib/lean_types.dart
@@ -21,6 +21,7 @@ enum Params {
   access_from,
   reconnect_id,
   show_balances,
+  allow_payment_source_change,
   customization,
   implementation,
   bank_identifier,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lean_sdk_flutter
 description: Lean SDK Flutter.
-version: 3.0.17
+version: 3.0.18
 homepage: https://github.com/leantechnologies/link-sdk-flutter
 
 environment:

--- a/test/lean_test.dart
+++ b/test/lean_test.dart
@@ -20,7 +20,7 @@ void main() {
     group('connect', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments';
 
         final initializationURL = leanSdk.connect(
           customerId: customerId,
@@ -44,7 +44,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments&bank_identifier=LEANMB1_SAU&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_to=10-10-2023&access_from=10-05-2023&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&customer_metadata={"user":"test"}';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments&bank_identifier=LEANMB1_SAU&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_to=10-10-2023&access_from=10-05-2023&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&customer_metadata={"user":"test"}';
 
         final initializationURL = leanSdk.connect(
             customerId: customerId,
@@ -73,7 +73,7 @@ void main() {
     group('reconnect', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.reconnect(
           reconnectId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -84,7 +84,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.reconnect(
             reconnectId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -99,7 +99,7 @@ void main() {
     group('createBeneficiary', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.createBeneficiary(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -110,7 +110,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.createBeneficiary(
             accessToken: 'test',
@@ -130,7 +130,7 @@ void main() {
     group('createPaymentSource', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.createPaymentSource(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -141,7 +141,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&bank_identifier=LEANMB1_SAU&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&bank_identifier=LEANMB1_SAU&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.createPaymentSource(
             accessToken: 'test',
@@ -160,7 +160,7 @@ void main() {
     group('updatePaymentSource', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.updatePaymentSource(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -173,7 +173,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.updatePaymentSource(
             accessToken: 'test',
@@ -193,7 +193,7 @@ void main() {
     group('pay', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.pay(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -216,13 +216,14 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&account_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&show_balances=true&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&account_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&show_balances=true&allow_payment_source_change=true&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.pay(
             accessToken: 'test',
             paymentIntentId: "617207b3-a4d4-4413-ba1b-b8d32efd58a0",
             accountId: "617207b3-a4d4-4413-ba1b-b8d32efd58a0",
             showBalances: true,
+            allowPaymentSourceChange: true,
             failRedirectUrl: 'https://dev.leantech.me/fail',
             successRedirectUrl: 'https://dev.leantech.me/success',
             destinationAlias: 'TestingCo',
@@ -236,7 +237,7 @@ void main() {
     group('verifyAddress', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity';
 
         final initializationURL = leanSdk.verifyAddress(
             customerId: 'test-customer-id',
@@ -248,7 +249,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity&access_token=test-access-token&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity&access_token=test-access-token&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.verifyAddress(
             customerId: 'test-customer-id',
@@ -265,7 +266,7 @@ void main() {
     group('authorizeConsent', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success';
 
         final initializationURL = leanSdk.authorizeConsent(
             customerId: 'b2f3537b-2e38-4067-bf61-7398cf7d4934',
@@ -290,7 +291,7 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&access_token=test-access-token&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&access_token=test-access-token&allow_payment_source_change=true&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.authorizeConsent(
             customerId: 'b2f3537b-2e38-4067-bf61-7398cf7d4934',
@@ -298,6 +299,7 @@ void main() {
             failRedirectUrl: 'https://www.leantech.me/failure',
             successRedirectUrl: 'https://www.leantech.me/success',
             accessToken: 'test-access-token',
+            allowPaymentSourceChange: true,
             destinationAlias: 'TestingCo',
             destinationAvatar: 'https://dev.leantech.me/success.png',
             riskDetails: riskDetails);
@@ -309,7 +311,7 @@ void main() {
     group('checkout', () {
       test('required params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail';
 
         final initializationURL = leanSdk.checkout(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -334,7 +336,7 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&access_token=test-access-token&customer_name=John Doe&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&access_token=test-access-token&customer_name=John Doe&allow_payment_source_change=true&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.checkout(
             paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -342,6 +344,7 @@ void main() {
             failRedirectUrl: 'https://dev.leantech.me/fail',
             accessToken: 'test-access-token',
             customerName: 'John Doe',
+            allowPaymentSourceChange: true,
             riskDetails: riskDetails);
 
         expect(initializationURL, equals(expectedUrl));
@@ -349,7 +352,7 @@ void main() {
 
       test('with bankIdentifier: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&customer_name=John Doe&bank_identifier=LEANMB1_SAU';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&customer_name=John Doe&bank_identifier=LEANMB1_SAU';
 
         final initializationURL = leanSdk.checkout(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -366,7 +369,7 @@ void main() {
     group('manageConsents', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.manageConsents(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -377,7 +380,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token';
 
         final initializationURL = leanSdk.manageConsents(
             customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -390,7 +393,7 @@ void main() {
     group('captureRedirect', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.captureRedirect(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -401,7 +404,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.14&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token&consent_attempt_id=7ebe7449-fd93-4657-be82-fcc3697262c4&granular_status_code=SUCCESS&status_additional_info=Additional info';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token&consent_attempt_id=7ebe7449-fd93-4657-be82-fcc3697262c4&granular_status_code=SUCCESS&status_additional_info=Additional info';
 
         final initializationURL = leanSdk.captureRedirect(
             customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',

--- a/test/lean_test.dart
+++ b/test/lean_test.dart
@@ -306,6 +306,21 @@ void main() {
 
         expect(initializationURL, equals(expectedUrl));
       });
+
+      test('with bankIdentifier and accountId: returns the correct URL', () {
+        const expectedUrl =
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&bank_identifier=LEANMB1_SAU&account_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540';
+
+        final initializationURL = leanSdk.authorizeConsent(
+            customerId: 'b2f3537b-2e38-4067-bf61-7398cf7d4934',
+            consentId: '7ebe7449-fd93-4657-be82-fcc3697262c4',
+            failRedirectUrl: 'https://www.leantech.me/failure',
+            successRedirectUrl: 'https://www.leantech.me/success',
+            bankIdentifier: 'LEANMB1_SAU',
+            accountId: '8b3b7960-c4a1-41da-8ad0-5df36cf67540');
+
+        expect(initializationURL, equals(expectedUrl));
+      });
     });
 
     group('checkout', () {
@@ -360,6 +375,20 @@ void main() {
           failRedirectUrl: 'https://dev.leantech.me/fail',
           customerName: 'John Doe',
           bankIdentifier: 'LEANMB1_SAU',
+        );
+
+        expect(initializationURL, equals(expectedUrl));
+      });
+
+      test('with accountId: returns the correct URL', () {
+        const expectedUrl =
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&account_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540';
+
+        final initializationURL = leanSdk.checkout(
+          paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
+          successRedirectUrl: 'https://dev.leantech.me/success',
+          failRedirectUrl: 'https://dev.leantech.me/fail',
+          accountId: '8b3b7960-c4a1-41da-8ad0-5df36cf67540',
         );
 
         expect(initializationURL, equals(expectedUrl));


### PR DESCRIPTION
[PBB-669]

- Added `allowPaymentSourceChange` as an optional parameter to `pay`, `authorizeConsent`, and `checkout` methods.
- Supported `accountId` and `bankIdentifier` in `checkout` and `authorizeConsent` methods.
- Updated CHANGELOG to reflect these changes.

[PBB-669]: https://leantechnologies.atlassian.net/browse/PBB-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ