### PR TITLE
PBB-725 support consentId and consentType in manageConsents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.19
+
+- Add `consentId` and `consentType` as optional parameters to the `manageConsents` method.
+
 ## 3.0.18
 
 - Add `allowPaymentSourceChange` as an optional parameter to `pay`, `authorizeConsent`, and `checkout` methods.

--- a/example/README.md
+++ b/example/README.md
@@ -233,6 +233,7 @@ Initiates a payment using a payment intent.
 - Account ID
 - Bank Identifier
 - Show Balances
+- Allow Payment Source Change
 - Fail Redirect URL
 - Success Redirect URL
 - Risk Details
@@ -263,6 +264,9 @@ Authorizes consent for account access with custom redirect URLs.
 
 **Optional Parameters:**
 - Access Token
+- Bank Identifier
+- Account ID
+- Allow Payment Source Change
 - Risk Details
 
 ### 9. Checkout
@@ -279,6 +283,8 @@ Initiates a streamlined checkout payment flow.
 - Access Token
 - Customer Name
 - Bank Identifier
+- Account ID
+- Allow Payment Source Change
 - Risk Details
 
 ### 10. Manage Consents
@@ -291,6 +297,8 @@ Displays and manages a customer's existing consents.
 
 **Optional Parameters:**
 - Access Token
+- Consent ID
+- Consent Type
 
 ### 11. Capture Redirect
 

--- a/lib/lean.dart
+++ b/lib/lean.dart
@@ -55,7 +55,7 @@ class LeanSDK {
       "platform": "mobile",
       "sdk": "flutter",
       "os": Platform.operatingSystem.toString(),
-      "sdk_version": '3.0.18', // @todo: get this dynamically from pubspec.yaml
+      "sdk_version": '3.0.19', // @todo: get this dynamically from pubspec.yaml
       "is_version_pinned": _version != "latest"
     };
 
@@ -505,6 +505,8 @@ class LeanSDK {
   manageConsents({
     required String customerId,
     String? accessToken,
+    String? consentId,
+    String? consentType,
   }) {
     String customizationParams = _convertCustomizationToURLString();
 
@@ -513,6 +515,8 @@ class LeanSDK {
 
     final optionalParams = {
       Params.access_token.name: accessToken,
+      Params.consent_id.name: consentId,
+      Params.consent_type.name: consentType,
     };
 
     initializationURL = _appendOptionalConfigToURLParams(

--- a/lib/lean_sdk_flutter.dart
+++ b/lib/lean_sdk_flutter.dart
@@ -35,6 +35,7 @@ class Lean extends StatefulWidget {
   final String? customerName;
   final String? reconnectId;
   final String? consentId;
+  final String? consentType;
   final bool? showBalances;
   final bool? allowPaymentSourceChange;
   final LeanCallback? callback;
@@ -93,6 +94,7 @@ class Lean extends StatefulWidget {
         reconnectId = null,
         customerName = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         paymentSourceId = null,
         paymentIntentId = null,
@@ -128,6 +130,7 @@ class Lean extends StatefulWidget {
         permissions = null,
         customerName = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         bankIdentifier = null,
         paymentSourceId = null,
@@ -172,6 +175,7 @@ class Lean extends StatefulWidget {
         customerName = null,
         reconnectId = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         bankIdentifier = null,
         paymentIntentId = null,
@@ -214,6 +218,7 @@ class Lean extends StatefulWidget {
         customerName = null,
         reconnectId = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         paymentIntentId = null,
         customerMetadata = null,
@@ -254,6 +259,7 @@ class Lean extends StatefulWidget {
         customerName = null,
         reconnectId = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         bankIdentifier = null,
         paymentIntentId = null,
@@ -297,6 +303,7 @@ class Lean extends StatefulWidget {
         permissions = null,
         customerName = null,
         consentId = null,
+        consentType = null,
         paymentSourceId = null,
         customerMetadata = null,
         showConsentExplanation = null,
@@ -335,6 +342,7 @@ class Lean extends StatefulWidget {
         accountId = null,
         reconnectId = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         paymentSourceId = null,
         paymentIntentId = null,
@@ -370,6 +378,7 @@ class Lean extends StatefulWidget {
     this.destinationAlias,
     this.destinationAvatar,
   })  : _method = LeanMethods.authorizeConsent,
+        consentType = null,
         accessTo = null,
         accessFrom = null,
         reconnectId = null,
@@ -415,6 +424,7 @@ class Lean extends StatefulWidget {
         paymentDestinationId = null,
         reconnectId = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         paymentSourceId = null,
         customerMetadata = null,
@@ -432,6 +442,8 @@ class Lean extends StatefulWidget {
     required this.customerId,
     this.callback,
     this.accessToken,
+    this.consentId,
+    this.consentType,
     this.customization,
     this.actionCancelled,
     this.isSandbox = true,
@@ -452,7 +464,6 @@ class Lean extends StatefulWidget {
         accountId = null,
         reconnectId = null,
         customerName = null,
-        consentId = null,
         showBalances = null,
         paymentSourceId = null,
         paymentIntentId = null,
@@ -497,6 +508,7 @@ class Lean extends StatefulWidget {
         reconnectId = null,
         customerName = null,
         consentId = null,
+        consentType = null,
         showBalances = null,
         paymentSourceId = null,
         paymentIntentId = null,
@@ -644,7 +656,10 @@ class _LeanState extends State<Lean> {
 
   String get _manageConsents {
     return _leanSdk.manageConsents(
-        customerId: widget.customerId!, accessToken: widget.accessToken);
+        customerId: widget.customerId!,
+        accessToken: widget.accessToken,
+        consentId: widget.consentId,
+        consentType: widget.consentType);
   }
 
   String get _captureRedirect {

--- a/lib/lean_types.dart
+++ b/lib/lean_types.dart
@@ -40,6 +40,7 @@ enum Params {
   destination_alias,
   destination_avatar,
   consent_id,
+  consent_type,
   consent_attempt_id,
   granular_status_code,
   status_additional_info,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lean_sdk_flutter
 description: Lean SDK Flutter.
-version: 3.0.18
+version: 3.0.19
 homepage: https://github.com/leantechnologies/link-sdk-flutter
 
 environment:

--- a/test/lean_test.dart
+++ b/test/lean_test.dart
@@ -20,7 +20,7 @@ void main() {
     group('connect', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments';
 
         final initializationURL = leanSdk.connect(
           customerId: customerId,
@@ -44,7 +44,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments&bank_identifier=LEANMB1_SAU&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_to=10-10-2023&access_from=10-05-2023&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&customer_metadata={"user":"test"}';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=connect&customer_id=dda80d32-4062-404c-abe7-ba9b9290c873&permissions=identity&permissions=accounts&permissions=balance&permissions=transactions&permissions=payments&bank_identifier=LEANMB1_SAU&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_to=10-10-2023&access_from=10-05-2023&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&customer_metadata={"user":"test"}';
 
         final initializationURL = leanSdk.connect(
             customerId: customerId,
@@ -73,7 +73,7 @@ void main() {
     group('reconnect', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.reconnect(
           reconnectId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -84,7 +84,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=reconnect&reconnect_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.reconnect(
             reconnectId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -99,7 +99,7 @@ void main() {
     group('createBeneficiary', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.createBeneficiary(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -110,7 +110,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createBeneficiary&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.createBeneficiary(
             accessToken: 'test',
@@ -130,7 +130,7 @@ void main() {
     group('createPaymentSource', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.createPaymentSource(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -141,7 +141,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&bank_identifier=LEANMB1_SAU&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=createPaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&bank_identifier=LEANMB1_SAU&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.createPaymentSource(
             accessToken: 'test',
@@ -160,7 +160,7 @@ void main() {
     group('updatePaymentSource', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.updatePaymentSource(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -173,7 +173,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=updatePaymentSource&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&payment_source_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540&payment_destination_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test&entity_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.updatePaymentSource(
             accessToken: 'test',
@@ -193,7 +193,7 @@ void main() {
     group('pay', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.pay(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -216,7 +216,7 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&account_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&show_balances=true&allow_payment_source_change=true&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&account_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&show_balances=true&allow_payment_source_change=true&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.pay(
             accessToken: 'test',
@@ -237,7 +237,7 @@ void main() {
     group('verifyAddress', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity';
 
         final initializationURL = leanSdk.verifyAddress(
             customerId: 'test-customer-id',
@@ -249,7 +249,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity&access_token=test-access-token&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=verifyAddress&customer_id=test-customer-id&customer_name=test-customer-name&permissions=identity&access_token=test-access-token&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png';
 
         final initializationURL = leanSdk.verifyAddress(
             customerId: 'test-customer-id',
@@ -266,7 +266,7 @@ void main() {
     group('authorizeConsent', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success';
 
         final initializationURL = leanSdk.authorizeConsent(
             customerId: 'b2f3537b-2e38-4067-bf61-7398cf7d4934',
@@ -291,7 +291,7 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&access_token=test-access-token&allow_payment_source_change=true&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&access_token=test-access-token&allow_payment_source_change=true&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.authorizeConsent(
             customerId: 'b2f3537b-2e38-4067-bf61-7398cf7d4934',
@@ -309,7 +309,7 @@ void main() {
 
       test('with bankIdentifier and accountId: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&bank_identifier=LEANMB1_SAU&account_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=authorizeConsent&customer_id=b2f3537b-2e38-4067-bf61-7398cf7d4934&consent_id=7ebe7449-fd93-4657-be82-fcc3697262c4&fail_redirect_url=https://www.leantech.me/failure&success_redirect_url=https://www.leantech.me/success&bank_identifier=LEANMB1_SAU&account_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540';
 
         final initializationURL = leanSdk.authorizeConsent(
             customerId: 'b2f3537b-2e38-4067-bf61-7398cf7d4934',
@@ -326,7 +326,7 @@ void main() {
     group('checkout', () {
       test('required params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail';
 
         final initializationURL = leanSdk.checkout(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -351,7 +351,7 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&access_token=test-access-token&customer_name=John Doe&allow_payment_source_change=true&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&access_token=test-access-token&customer_name=John Doe&allow_payment_source_change=true&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.checkout(
             paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -367,7 +367,7 @@ void main() {
 
       test('with bankIdentifier: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&customer_name=John Doe&bank_identifier=LEANMB1_SAU';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&customer_name=John Doe&bank_identifier=LEANMB1_SAU';
 
         final initializationURL = leanSdk.checkout(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -382,7 +382,7 @@ void main() {
 
       test('with accountId: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&account_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=checkout&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&success_redirect_url=https://dev.leantech.me/success&fail_redirect_url=https://dev.leantech.me/fail&account_id=8b3b7960-c4a1-41da-8ad0-5df36cf67540';
 
         final initializationURL = leanSdk.checkout(
           paymentIntentId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -398,7 +398,7 @@ void main() {
     group('manageConsents', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.manageConsents(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -409,11 +409,13 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=manageConsents&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token&consent_id=test-consent-id&consent_type=test-consent-type';
 
         final initializationURL = leanSdk.manageConsents(
             customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
-            accessToken: 'test-access-token');
+            accessToken: 'test-access-token',
+            consentId: 'test-consent-id',
+            consentType: 'test-consent-type');
 
         expect(initializationURL, equals(expectedUrl));
       });
@@ -422,7 +424,7 @@ void main() {
     group('captureRedirect', () {
       test('partial params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0';
 
         final initializationURL = leanSdk.captureRedirect(
           customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',
@@ -433,7 +435,7 @@ void main() {
 
       test('all params: returns the correct URL', () {
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.18&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token&consent_attempt_id=7ebe7449-fd93-4657-be82-fcc3697262c4&granular_status_code=SUCCESS&status_additional_info=Additional info';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=captureRedirect&customer_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&access_token=test-access-token&consent_attempt_id=7ebe7449-fd93-4657-be82-fcc3697262c4&granular_status_code=SUCCESS&status_additional_info=Additional info';
 
         final initializationURL = leanSdk.captureRedirect(
             customerId: '617207b3-a4d4-4413-ba1b-b8d32efd58a0',


### PR DESCRIPTION
[PBB-725]

Add `consentId` and `consentType` as optional params for the `manageConsents` method.

- Add `consent_type` to the `Params` enum (`consent_id` already existed).
- Add both to the `LeanSdk.manageConsents` builder and the `Lean.manageConsents` widget constructor (with the matching `null` initializers on the other constructors).
- Update `lean_test.dart`.
- Bump version 3.0.18 → 3.0.19 (pubspec, CHANGELOG, and the hardcoded `sdk_version` in `lean.dart`).

[PBB-725]: https://leantechnologies.atlassian.net/browse/PBB-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ