### PR TITLE
PBB-706 support consentId in pay method

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -234,6 +234,7 @@ Initiates a payment using a payment intent.
 - Bank Identifier
 - Show Balances
 - Allow Payment Source Change
+- Consent ID
 - Fail Redirect URL
 - Success Redirect URL
 - Risk Details

--- a/lib/lean.dart
+++ b/lib/lean.dart
@@ -373,6 +373,7 @@ class LeanSDK {
     String? destinationAvatar,
     RiskDetails? riskDetails,
     bool? allowPaymentSourceChange,
+    String? consentId,
   }) {
     String customizationParams = _convertCustomizationToURLString();
 
@@ -385,6 +386,7 @@ class LeanSDK {
       Params.account_id.name: accountId,
       Params.bank_identifier.name: bankIdentifier,
       Params.show_balances.name: showBalances,
+      Params.consent_id.name: consentId,
       Params.allow_payment_source_change.name: allowPaymentSourceChange,
       Params.access_token.name: accessToken,
       Params.fail_redirect_url.name: failRedirectUrl,

--- a/lib/lean_sdk_flutter.dart
+++ b/lib/lean_sdk_flutter.dart
@@ -295,6 +295,7 @@ class Lean extends StatefulWidget {
     this.riskDetails,
     this.destinationAlias,
     this.destinationAvatar,
+    this.consentId,
   })  : _method = LeanMethods.pay,
         accessTo = null,
         customerId = null,
@@ -302,7 +303,6 @@ class Lean extends StatefulWidget {
         reconnectId = null,
         permissions = null,
         customerName = null,
-        consentId = null,
         consentType = null,
         paymentSourceId = null,
         customerMetadata = null,
@@ -613,7 +613,8 @@ class _LeanState extends State<Lean> {
         accessToken: widget.accessToken,
         riskDetails: widget.riskDetails,
         destinationAlias: widget.destinationAlias,
-        destinationAvatar: widget.destinationAvatar);
+        destinationAvatar: widget.destinationAvatar,
+        consentId: widget.consentId);
   }
 
   String get _verifyAddress {

--- a/test/lean_test.dart
+++ b/test/lean_test.dart
@@ -216,7 +216,7 @@ void main() {
             "%7B%22debtor_indicators%22%3A%7B%22geo_location%22%3A%7B%22latitude%22%3A1.0%2C%22longitude%22%3A1.0%7D%7D%7D";
 
         const expectedUrl =
-            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&account_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&show_balances=true&allow_payment_source_change=true&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
+            'https://cdn.leantech.me/link/loader/prod/ae/latest/lean-sdk.html?implementation=webview-hosted-html&implementation_config=platform+mobile&implementation_config=sdk+flutter&implementation_config=os+macos&implementation_config=sdk_version+3.0.19&implementation_config=is_version_pinned+false&app_token=9fb9e934-9efb-4e7e-a508-de67c0839be0&sandbox=false&language=en&version=latest&country=ae&env=production&method=pay&payment_intent_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&account_id=617207b3-a4d4-4413-ba1b-b8d32efd58a0&show_balances=true&consent_id=test-consent-id&allow_payment_source_change=true&access_token=test&fail_redirect_url=https://dev.leantech.me/fail&success_redirect_url=https://dev.leantech.me/success&destination_alias=TestingCo&destination_avatar=https://dev.leantech.me/success.png&risk_details=$expectedSerilizedRiskDetails';
 
         final initializationURL = leanSdk.pay(
             accessToken: 'test',
@@ -224,6 +224,7 @@ void main() {
             accountId: "617207b3-a4d4-4413-ba1b-b8d32efd58a0",
             showBalances: true,
             allowPaymentSourceChange: true,
+            consentId: 'test-consent-id',
             failRedirectUrl: 'https://dev.leantech.me/fail',
             successRedirectUrl: 'https://dev.leantech.me/success',
             destinationAlias: 'TestingCo',


### PR DESCRIPTION
[PBB-706]

Support the `consentId` param in the `pay` method.

- `lib/lean.dart`: add optional `consentId` to `pay(...)` and to the optional params (`Params.consent_id`).
- `lib/lean_sdk_flutter.dart`: add `consentId` to the `Lean.pay` constructor (removed from the null-initializer list) and forward it to `_leanSdk.pay`.
- `test/lean_test.dart`: assert `consent_id` in the pay all-params test.
- `example/README.md`: document `Consent ID` as an optional pay param.


[PBB-706]: https://leantechnologies.atlassian.net/browse/PBB-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ